### PR TITLE
fix: refine social link hover state

### DIFF
--- a/src/components/Socials.astro
+++ b/src/components/Socials.astro
@@ -49,6 +49,6 @@ const textLabels: Record<string, string> = {
     @apply gap-x-1 gap-y-0;
   }
   .text-links :global(a) {
-    @apply inline-flex min-h-11 items-center rounded-xl px-3 text-sm text-skin-muted transition-colors hover:bg-skin-card/65 hover:text-skin-accent;
+    @apply inline-flex min-h-11 items-center px-3 text-sm text-skin-muted underline decoration-transparent underline-offset-8 transition-[color,text-decoration-color] hover:text-skin-accent hover:decoration-skin-accent;
   }
 </style>


### PR DESCRIPTION
## Summary
- 移除文字型社交链接 hover 时的大面积圆角底色
- 改为强调色文字与细下划线反馈
- 保留原有点击热区、键盘 focus 与响应式布局

## Validation
- npm exec prettier -- --check src/components/Socials.astro
- git diff --check
- npm run build
- npm run test:ui -- tests/open.spec.ts tests/responsive-cards.spec.ts（8 passed）
- 人工检查 390、768、1024、1440、1600px 及深色模式